### PR TITLE
Add prerequisites for txjuju.cli.CLI.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,4 +17,4 @@ lint:
 
 .PHONY: install-dev
 install-dev:
-	ln -s $(shell pwd)/txjuju /usr/local/lib/python2.7/dist-packages/txjuju
+	ln -snv $(shell pwd)/txjuju /usr/local/lib/python2.7/dist-packages/txjuju

--- a/Makefile
+++ b/Makefile
@@ -14,3 +14,7 @@ coverage:
 lint:
 	# sudo apt-get install python-flake8
 	$(PYTHON) -m flake8 .
+
+.PHONY: install-dev
+install-dev:
+	ln -s $(shell pwd)/txjuju /usr/local/lib/python2.7/dist-packages/txjuju

--- a/txjuju/__init__.py
+++ b/txjuju/__init__.py
@@ -1,9 +1,17 @@
 # Copyright 2016 Canonical Limited.  All rights reserved.
 
-# Expose all the error classes at the top level.
 from .errors import (
     CLIError, APIRequestError, APIAuthError, APIRetriableError,
     AllWatcherStoppedError, InvalidAPIEndpointAddress)
+
+
+__all__ = [
+    "__version__", "JUJU1", "JUJU2",
+    "get_cli_class", "prepare_for_bootstrap",
+    # errors
+    "CLIError", "APIRequestError", "APIAuthError", "APIRetriableError",
+    "AllWatcherStoppedError", "InvalidAPIEndpointAddress",
+    ]
 
 
 __version__ = "0.9.0a1"
@@ -40,8 +48,3 @@ def prepare_for_bootstrap(spec, version, cfgdir):
     cfg = spec.config()
     filenames = cfg.write(cfgdir, version)
     return filenames.get(spec.name) if filenames else None
-
-
-# Appease pyflakes
-(CLIError, APIRequestError, APIAuthError, APIRetriableError,
-    AllWatcherStoppedError, InvalidAPIEndpointAddress)

--- a/txjuju/__init__.py
+++ b/txjuju/__init__.py
@@ -24,6 +24,24 @@ def get_cli_class(release=JUJU1):
         raise ValueError("unsupported release {!r}".format(release))
 
 
+def prepare_for_bootstrap(spec, version, cfgdir):
+    """Return the bootstrap config filename after creating configs.
+
+    Note that not all Juju versions have a bootstrap config.  In that
+    case None will be returned.
+
+    @param spec: The txjuju.cli.BootstrapSpec for which to prepare.
+    @param version: The Juju version to prepare for.
+    @param cfgdir: The Juju config directory to use.
+    """
+    # For now we don't bother with config files for 2.x.
+    if version.startswith("2."):
+        return None
+    cfg = spec.config()
+    filenames = cfg.write(cfgdir, version)
+    return filenames.get(spec.name) if filenames else None
+
+
 # Appease pyflakes
 (CLIError, APIRequestError, APIAuthError, APIRetriableError,
     AllWatcherStoppedError, InvalidAPIEndpointAddress)

--- a/txjuju/_juju1.py
+++ b/txjuju/_juju1.py
@@ -41,7 +41,7 @@ class ConfigWriter(object):
         @param env: A JujuControllerConfig to serialize for Juju 1.x.
         """
         config = {
-            "type": env.cloud.type,
+            "type": env.cloud.driver,
             }
         if env.bootstrap.default_series:
             config["default-series"] = env.bootstrap.default_series

--- a/txjuju/_juju2.py
+++ b/txjuju/_juju2.py
@@ -71,7 +71,7 @@ class ConfigWriter(object):
             raise NotImplementedError
         else:
             config = {
-                "type": cloud.type,
+                "type": cloud.driver,
                 }
             if cloud.endpoint:
                 config["endpoint"] = str(cloud.endpoint)

--- a/txjuju/_utils.py
+++ b/txjuju/_utils.py
@@ -1,0 +1,53 @@
+# Copyright 2016 Canonical Limited.  All rights reserved.
+
+import subprocess
+from collections import namedtuple
+
+
+class Executable(namedtuple("Executable", "filename envvars")):
+    """A single executable."""
+
+    def __new__(cls, filename, envvars=None):
+        """
+        @param filename: The path to the executable file.
+        @param envvars: The environment variables with which
+            to run the executable.
+        """
+        filename = str(filename) if filename else None
+        if envvars is not None:
+            if not hasattr(envvars, "items"):
+                envvars = dict(envvars)
+            envvars = {str(k): str(v) for k, v in envvars.items() if v}
+        return super(Executable, cls).__new__(cls, filename, envvars)
+
+    def __init__(self, *args, **kwargs):
+        if not self.filename:
+            raise ValueError("missing filename")
+
+    @property
+    def envvars(self):
+        """The environment variables used when running the executable."""
+        envvars = super(Executable, self).envvars
+        if envvars is None:
+            return None
+        return dict(envvars)
+
+    def resolve_args(self, *args):
+        """Return the full args to pass to subprocess.*."""
+        return [self.filename] + list(args)
+
+    def run(self, *args, **kwargs):
+        """Run the executable with the given args.
+
+        The provided kwargs are those that subprocess.* supports.
+        """
+        args = self.resolve_args(*args)
+        subprocess.check_call(args, env=self.envvars, **kwargs)
+
+    def run_out(self, *args, **kwargs):
+        """Return the output from running the executable with the given args.
+
+        The provided kwargs are those that subprocess.* supports.
+        """
+        args = self.resolve_args(*args)
+        return subprocess.check_output(args, env=self.envvars, **kwargs)

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -67,7 +67,7 @@ class BootstrapSpec(object):
         return "{}({})".format(
             type(self).__name__,
             ', '.join("{}={!r}".format(name, getattr(self, name))
-                                       for name in self._fields),
+                      for name in self._fields),
             )
 
     def __eq__(self, other):

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -103,6 +103,11 @@ class APIInfo(namedtuple("APIInfo", "endpoints user password model_uuid")):
         if not self.password:
             raise ValueError("missing password")
 
+    @property
+    def address(self):
+        """The primary API endpoint address to use."""
+        return self.endpoints[0]
+
 
 class Juju1CLI(object):
 

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -45,6 +45,7 @@ class BootstrapSpec(object):
         controller = config.ControllerConfig.from_info(
             self.name,
             self.type,
+            cloud_name=self.type,
             default_series=self.default_series,
             admin_secret=self.admin_secret,
             )

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -41,15 +41,13 @@ class BootstrapSpec(object):
 
     def config(self):
         """Return the JujuConfig corresponding to this spec."""
-        cloud_name = self.type
-        controller = config.JujuControllerConfig.from_info(
+        controller = config.ControllerConfig.from_info(
             self.name,
             self.type,
-            cloud_name,
-            self.default_series,
-            self.admin_secret,
+            default_series=self.default_series,
+            admin_secret=self.admin_secret,
             )
-        return config.JujuConfig(controller)
+        return config.Config(controller)
 
 
 class Juju1CLI(object):

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -44,10 +44,10 @@ class BootstrapSpec(object):
 
     DEFAULT_SERIES = "trusty"
 
-    def __init__(self, name, type, default_series=None, admin_secret=None):
+    def __init__(self, name, driver, default_series=None, admin_secret=None):
         """
         @param name: The name of the controller to bootstrap.
-        @param type: The provider type to use.
+        @param driver: The provider type to use.
         @param default_series: The OS series to provision by default.
             If not provided, it defaults to trusty.
         @param admin_secret: The password to use for the admin user,
@@ -57,7 +57,7 @@ class BootstrapSpec(object):
             default_series = self.DEFAULT_SERIES
 
         self.name = name
-        self.type = type
+        self.driver = driver
         self.default_series = default_series
         self.admin_secret = admin_secret
 
@@ -88,8 +88,8 @@ class BootstrapSpec(object):
         """Return the JujuConfig corresponding to this spec."""
         controller = config.ControllerConfig.from_info(
             self.name,
-            self.type,
-            cloud_name=self.type,
+            self.driver,
+            cloud_name=self.driver,
             default_series=self.default_series,
             admin_secret=self.admin_secret,
             )

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -13,7 +13,43 @@ from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
 from twisted.internet.protocol import ProcessProtocol
 from twisted.python import log
 
+from . import config
 from .errors import CLIError
+
+
+class BootstrapSpec(object):
+    """A specification of the information with which to bootstrap."""
+
+    DEFAULT_SERIES = "trusty"
+
+    def __init__(self, name, type, default_series=None, admin_secret=None):
+        """
+        @param name: The name of the controller to bootstrap.
+        @param type: The provider type to use.
+        @param default_series: The OS series to provision by default.
+            If not provided, it defaults to trusty.
+        @param admin_secret: The password to use for the admin user,
+            if any.
+        """
+        if default_series is None:
+            default_series = self.DEFAULT_SERIES
+
+        self.name = name
+        self.type = type
+        self.default_series = default_series
+        self.admin_secret = admin_secret
+
+    def config(self):
+        """Return the JujuConfig corresponding to this spec."""
+        cloud_name = self.type
+        controller = config.JujuControllerConfig.from_info(
+            self.name,
+            self.type,
+            cloud_name,
+            self.default_series,
+            self.admin_secret,
+            )
+        return config.JujuConfig(controller)
 
 
 class Juju1CLI(object):

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -61,6 +61,15 @@ class BootstrapSpec(object):
         self.default_series = default_series
         self.admin_secret = admin_secret
 
+    _fields = __init__.__code__.co_varnames[1:]
+
+    def __repr__(self):
+        return "{}({})".format(
+            type(self).__name__,
+            ', '.join("{}={!r}".format(name, getattr(self, name))
+                                       for name in self._fields),
+            )
+
     def config(self):
         """Return the JujuConfig corresponding to this spec."""
         controller = config.ControllerConfig.from_info(

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -14,8 +14,29 @@ from twisted.internet.defer import inlineCallbacks, returnValue, Deferred
 from twisted.internet.protocol import ProcessProtocol
 from twisted.python import log
 
-from . import config
+from . import config, _utils
 from .errors import CLIError
+
+
+def get_executable(filename, version_cli, cfgdir, envvars=None):
+    """Return the Executable for the given juju binary.
+
+    @param filename: The path to the juju binary.
+    @param version_cli: The version-specific JujuXCLI to use.
+    @param cfgdir: The Juju config dir to use.
+    @param envvars: The additional environment variables to use.
+    """
+    if not version_cli:
+        raise ValueError("missing version_cli")
+    if not cfgdir:
+        raise ValueError("missing cfgdir")
+
+    if envvars is None:
+        envvars = os.environ
+    envvars = dict(envvars)
+    envvars[version_cli.CFGDIR_ENVVAR] = cfgdir
+
+    return _utils.Executable(filename, envvars)
 
 
 class BootstrapSpec(object):

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -70,6 +70,20 @@ class BootstrapSpec(object):
                                        for name in self._fields),
             )
 
+    def __eq__(self, other):
+        for name in self._fields:
+            try:
+                other_val = getattr(other, name)
+            except AttributeError:
+                # TODO Return NotImplemented?
+                return False
+            if getattr(self, name) != other_val:
+                return False
+        return True
+
+    def __ne__(self, other):
+        return not (self == other)
+
     def config(self):
         """Return the JujuConfig corresponding to this spec."""
         controller = config.ControllerConfig.from_info(

--- a/txjuju/config.py
+++ b/txjuju/config.py
@@ -59,7 +59,7 @@ class ControllerConfig(
     DEFAULT_SERIES = "trusty"
 
     @classmethod
-    def from_info(cls, name, type,
+    def from_info(cls, name, driver,
                   cloud_name=None, default_series=None, admin_secret=None):
         """Return a new controller config for the given info.
 
@@ -67,20 +67,20 @@ class ControllerConfig(
         respective meaning (e.g. name -> an acceptable controller name).
 
         @param name: The name of the controller.
-        @param type: The controller's provider type.
-        @param cloud_name: The name of the cloud (defaults to <name>-<type>).
+        @param driver: The controller's provider type.
+        @param cloud_name: The name of the cloud (defaults to <name>-<driver>).
         @param default_series: The OS series to provision by default.
             If not provided, it defaults to trusty.
         @param admin_secret: The password to use for the admin user,
             if any.
         """
-        if cloud_name is None and name and type:
-            cloud_name = "{}-{}".format(name, type)
+        if cloud_name is None and name and driver:
+            cloud_name = "{}-{}".format(name, driver)
         # TODO Sort these out as soon as we need them.
         endpoint = auth_types = credentials = None
         return cls(
             name,
-            (cloud_name, type, endpoint, auth_types, credentials),
+            (cloud_name, driver, endpoint, auth_types, credentials),
             (default_series, admin_secret),
             )
 
@@ -118,17 +118,17 @@ class ControllerConfig(
 
 class CloudConfig(
         namedtuple("CloudConfig",
-                   "name type endpoint auth_types credentials")):
+                   "name driver endpoint auth_types credentials")):
     """An encapsulation of the local config for a single cloud."""
 
-    def __new__(cls, name, type=None, endpoint=None,
+    def __new__(cls, name, driver=None, endpoint=None,
                 auth_types=None, credentials=None):
         """
         All arguments must be values that juju will accept for the
         respective meaning (e.g. name -> an acceptable cloud name).
 
         @param name: The cloud's user-defined ID, e.g. "my-cloud".
-        @param type: The provider type, e.g. lxd, maas
+        @param driver: The provider driver, e.g. lxd, maas
             (defaults to the name).
         @param endpoint: The endpoint to use, if needed,  Any URL or
             hostname is okay, as long as the provider supports it.
@@ -139,23 +139,23 @@ class CloudConfig(
             <CURRENTLY NOT SUPPORTED>
         """
         name = unicode(name) if name else None
-        if type is None:
-            type = name
-        type = unicode(type) if type else None
+        if driver is None:
+            driver = name
+        driver = unicode(driver) if driver else None
         endpoint = unicode(endpoint) if endpoint else None
         # TODO Add provider-specific abstractions to support auth_types?
         # TODO Add support for auth_types and credentials as soon as needed.
         auth_types = tuple(auth_types) if auth_types else None
         credentials = tuple(credentials) if credentials else None
         return super(CloudConfig, cls).__new__(
-            cls, name, type, endpoint, auth_types, credentials)
+            cls, name, driver, endpoint, auth_types, credentials)
 
     def __init__(self, *args, **kwargs):
         super(CloudConfig, self).__init__(*args, **kwargs)
         if not self.name:
             raise ValueError("missing name")
-        if not self.type:
-            raise ValueError("missing type")
+        if not self.driver:
+            raise ValueError("missing driver")
         # TODO Add support for auth_types and credentials as soon as needed.
         if self.auth_types is not None or self.credentials is not None:
             raise NotImplementedError

--- a/txjuju/config.py
+++ b/txjuju/config.py
@@ -17,6 +17,11 @@ class Config(object):
         """
         self._controllers = controllers
 
+    @property
+    def controllers(self):
+        """Return the controller configs."""
+        return list(self._controllers)
+
     def write(self, cfgdir, version, clobber=False):
         """Save the config to disk.
 

--- a/txjuju/tests/test___init__.py
+++ b/txjuju/tests/test___init__.py
@@ -38,6 +38,10 @@ class PrepareForBootstrapTests(unittest.TestCase):
         super(PrepareForBootstrapTests, self).tearDown()
 
     def test_juju2(self):
+        """
+        prepare_for_bootstrap() for Juju 2.x results in no files.
+        This may change in the future.
+        """
         spec = cli.BootstrapSpec("spam", "lxd")
         version = "2.0.0"
         filename = txjuju.prepare_for_bootstrap(spec, version, self.cfgdir)
@@ -46,6 +50,10 @@ class PrepareForBootstrapTests(unittest.TestCase):
         self.assertEqual(os.listdir(self.cfgdir), [])
 
     def test_juju1(self):
+        """
+        prepare_for_bootstrap() for Juju 1.x results in
+        an environments.yaml file.
+        """
         spec = cli.BootstrapSpec("spam", "lxd")
         version = "1.25.6"
         filename = txjuju.prepare_for_bootstrap(spec, version, self.cfgdir)

--- a/txjuju/tests/test___init__.py
+++ b/txjuju/tests/test___init__.py
@@ -1,12 +1,15 @@
 # Copyright 2016 Canonical Limited.  All rights reserved.
 
+import os
+import shutil
+import tempfile
 import unittest
 
 import txjuju
 from txjuju import cli
 
 
-class GetCLIClassTest(unittest.TestCase):
+class GetCLIClassTests(unittest.TestCase):
 
     def test_juju1(self):
         """Passing in c.juju.JUJU1 should result in Juju1CLI."""
@@ -22,3 +25,30 @@ class GetCLIClassTest(unittest.TestCase):
         """Passing in an unrecognized release should cause an error."""
         with self.assertRaises(ValueError):
             txjuju.get_cli_class("<???>")
+
+
+class PrepareForBootstrapTests(unittest.TestCase):
+
+    def setUp(self):
+        super(PrepareForBootstrapTests, self).setUp()
+        self.cfgdir = tempfile.mkdtemp(prefix="txjuju-test-")
+
+    def tearDown(self):
+        shutil.rmtree(self.cfgdir)
+        super(PrepareForBootstrapTests, self).tearDown()
+
+    def test_juju2(self):
+        spec = cli.BootstrapSpec("spam", "lxd")
+        version = "2.0.0"
+        filename = txjuju.prepare_for_bootstrap(spec, version, self.cfgdir)
+
+        self.assertIsNone(filename)
+        self.assertEqual(os.listdir(self.cfgdir), [])
+
+    def test_juju1(self):
+        spec = cli.BootstrapSpec("spam", "lxd")
+        version = "1.25.6"
+        filename = txjuju.prepare_for_bootstrap(spec, version, self.cfgdir)
+
+        self.assertIsNone(filename)
+        self.assertEqual(os.listdir(self.cfgdir), ["environments.yaml"])

--- a/txjuju/tests/test__utils.py
+++ b/txjuju/tests/test__utils.py
@@ -1,0 +1,86 @@
+# Copyright 2016 Canonical Limited.  All rights reserved.
+
+import os
+import os.path
+import shutil
+import tempfile
+import unittest
+
+from txjuju._utils import Executable
+
+
+class ExecutableTests(unittest.TestCase):
+
+    def setUp(self):
+        super(ExecutableTests, self).setUp()
+        self.dirname = None
+
+    def tearDown(self):
+        if self.dirname is not None:
+            shutil.rmtree(self.dirname)
+        super(ExecutableTests, self).tearDown()
+
+    def _write_executable(self, filename):
+        if self.dirname is None:
+            self.dirname = tempfile.mkdtemp(prefix="txjuju-test-")
+        filename = os.path.join(self.dirname, filename)
+        with open(filename, "w") as file:
+            file.write("#!/bin/bash\necho $@\nenv")
+        os.chmod(filename, 0o755)
+        return filename
+
+    def test_full(self):
+        exe = Executable("my-exe", {"SPAM": "eggs"})
+
+        self.assertEqual(exe.filename, "my-exe")
+        self.assertEqual(exe.envvars, {"SPAM": "eggs"})
+
+    def test_minimal(self):
+        exe = Executable("my-exe")
+
+        self.assertEqual(exe.filename, "my-exe")
+        self.assertIsNone(exe.envvars)
+
+    def test_conversion(self):
+        exe = Executable(u"my-exe", [(u"SPAM", u"eggs"), ("ham", "")])
+
+        self.assertEqual(exe.filename, "my-exe")
+        self.assertEqual(exe.envvars, {"SPAM": "eggs"})
+
+    def test_missing_filename(self):
+        with self.assertRaises(ValueError):
+            Executable(None)
+        with self.assertRaises(ValueError):
+            Executable("")
+
+    def test_envvars(self):
+        exe = Executable("my-exe", {"SPAM": "eggs"})
+        exe.envvars["SPAM"] = "ham"
+
+        self.assertEqual(exe.envvars, {"SPAM": "eggs"})
+
+    def test_resolve_args(self):
+        exe = Executable("my-exe", {"SPAM": "eggs"})
+        args = exe.resolve_args("x", "-y", "z")
+
+        self.assertEqual(args, ["my-exe", "x", "-y", "z"])
+
+    def test_run(self):
+        filename = self._write_executable("script")
+        exe = Executable(filename, {"SPAM": "eggs"})
+        with tempfile.NamedTemporaryFile() as outfile:
+            exe.run("x", "-y", "z", stdout=outfile)
+            outfile.seek(0)
+            out = outfile.read()
+
+        self.assertTrue(out.startswith("x -y z\n"))
+        self.assertIn("SPAM=eggs\n", out)
+
+    def test_run_out(self):
+        filename = self._write_executable("script")
+        self.assertTrue(os.path.exists(filename))
+        exe = Executable(filename, {"SPAM": "eggs"})
+        out = exe.run_out("x", "-y", "z")
+
+        self.assertTrue(out.startswith("x -y z\n"))
+        self.assertIn("SPAM=eggs\n", out)

--- a/txjuju/tests/test__utils.py
+++ b/txjuju/tests/test__utils.py
@@ -30,42 +30,64 @@ class ExecutableTests(unittest.TestCase):
         return filename
 
     def test_full(self):
+        """
+        Executable() works when provided all arguments.
+        """
         exe = Executable("my-exe", {"SPAM": "eggs"})
 
         self.assertEqual(exe.filename, "my-exe")
         self.assertEqual(exe.envvars, {"SPAM": "eggs"})
 
     def test_minimal(self):
+        """
+        Executable() works with minimal arguments.
+        """
         exe = Executable("my-exe")
 
         self.assertEqual(exe.filename, "my-exe")
         self.assertIsNone(exe.envvars)
 
     def test_conversion(self):
+        """
+        Executable() converts the args to str.
+        """
         exe = Executable(u"my-exe", [(u"SPAM", u"eggs"), ("ham", "")])
 
         self.assertEqual(exe.filename, "my-exe")
         self.assertEqual(exe.envvars, {"SPAM": "eggs"})
 
     def test_missing_filename(self):
+        """
+        Executable() fails if filename is None or empty.
+        """
         with self.assertRaises(ValueError):
             Executable(None)
         with self.assertRaises(ValueError):
             Executable("")
 
     def test_envvars(self):
+        """
+        Executable.envvars gives a copy of the originally provided env vars.
+        """
         exe = Executable("my-exe", {"SPAM": "eggs"})
         exe.envvars["SPAM"] = "ham"
 
         self.assertEqual(exe.envvars, {"SPAM": "eggs"})
 
     def test_resolve_args(self):
+        """
+        Executable.resolve_args() returns the args list that may
+        be passed to subprocess.*().
+        """
         exe = Executable("my-exe", {"SPAM": "eggs"})
         args = exe.resolve_args("x", "-y", "z")
 
         self.assertEqual(args, ["my-exe", "x", "-y", "z"])
 
     def test_run(self):
+        """
+        Executable.run() runs the command and returns nothing.
+        """
         filename = self._write_executable("script")
         exe = Executable(filename, {"SPAM": "eggs"})
         with tempfile.NamedTemporaryFile() as outfile:
@@ -77,6 +99,9 @@ class ExecutableTests(unittest.TestCase):
         self.assertIn("SPAM=eggs\n", out)
 
     def test_run_out(self):
+        """
+        Executable.run_out() runs the command and returns stdout.
+        """
         filename = self._write_executable("script")
         self.assertTrue(os.path.exists(filename))
         exe = Executable(filename, {"SPAM": "eggs"})

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -131,6 +131,11 @@ class TestAPIInfo(unittest.TestCase):
         with self.assertRaises(ValueError):
             APIInfo(["host"], "admin", "")
 
+    def test_address(self):
+        info = APIInfo(["host2", "host1"], "admin", "pw")
+
+        self.assertEqual(info.address, "host2")
+
 
 class Juju1CLITest(TwistedTestCase, MockerTestCase):
     # XXX bug #1558600 to be removed with juju2 feature flag

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -9,7 +9,7 @@ from mocker import MockerTestCase
 from twisted.internet.defer import inlineCallbacks
 
 from txjuju import config
-from txjuju.cli import Juju1CLI, Juju2CLI, BootstrapSpec
+from txjuju.cli import Juju1CLI, Juju2CLI, BootstrapSpec, APIInfo
 from txjuju.errors import CLIError
 from txjuju.testing import TwistedTestCase
 
@@ -45,6 +45,54 @@ class TestBootstrapSpec(unittest.TestCase):
                 config.BootstrapConfig("xenial", "pw"),
                 ),
             )
+
+
+class TestAPIInfo(unittest.TestCase):
+
+    def test_full(self):
+        endpoints = (u"host2", u"host1")
+        info = APIInfo(endpoints, u"admin", u"pw", u"some-uuid")
+
+        self.assertEqual(info.endpoints, (u"host2", u"host1"))
+        self.assertEqual(info.user, u"admin")
+        self.assertEqual(info.password, u"pw")
+        self.assertEqual(info.model_uuid, u"some-uuid")
+
+    def test_minimal(self):
+        endpoints = (u"host",)
+        info = APIInfo(endpoints, u"admin", u"pw")
+
+        self.assertEqual(info.endpoints, (u"host",))
+        self.assertEqual(info.user, u"admin")
+        self.assertEqual(info.password, u"pw")
+        self.assertIsNone(info.model_uuid)
+
+    def test_conversion(self):
+        endpoints = ["host2", "host1"]
+        info = APIInfo(endpoints, "admin", "pw", "some-uuid")
+
+        self.assertEqual(info.endpoints, (u"host2", u"host1"))
+        self.assertEqual(info.user, u"admin")
+        self.assertEqual(info.password, u"pw")
+        self.assertEqual(info.model_uuid, u"some-uuid")
+
+    def test_missing_endpoints(self):
+        with self.assertRaises(ValueError):
+            APIInfo(None, "admin", "pw")
+        with self.assertRaises(ValueError):
+            APIInfo([], "admin", "pw")
+
+    def test_missing_user(self):
+        with self.assertRaises(ValueError):
+            APIInfo(["host"], None, "pw")
+        with self.assertRaises(ValueError):
+            APIInfo(["host"], "", "pw")
+
+    def test_missing_password(self):
+        with self.assertRaises(ValueError):
+            APIInfo(["host"], "admin", None)
+        with self.assertRaises(ValueError):
+            APIInfo(["host"], "admin", "")
 
 
 class Juju1CLITest(TwistedTestCase, MockerTestCase):

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -69,6 +69,20 @@ class TestBootstrapSpec(unittest.TestCase):
         self.assertEqual(spec.default_series, "trusty")
         self.assertIsNone(spec.admin_secret)
 
+    def test_repr(self):
+        spec = BootstrapSpec("my-env", "lxd", "xenial", "pw")
+        self.assertEqual(
+            repr(spec),
+            ("BootstrapSpec(name='my-env', type='lxd', "
+             "default_series='xenial', admin_secret='pw')"),
+            )
+        spec = BootstrapSpec("my-env", "lxd")
+        self.assertEqual(
+            repr(spec),
+            ("BootstrapSpec(name='my-env', type='lxd', "
+             "default_series='trusty', admin_secret=None)"),
+            )
+
     def test_config(self):
         spec = BootstrapSpec("my-env", "lxd", "xenial", "pw")
         cfg = spec.config()

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -92,7 +92,6 @@ class TestBootstrapSpec(unittest.TestCase):
 
         self.assertTrue(spec == other)
 
-
     def test___eq___same_with_sub_class(self):
         spec = BootstrapSpec("my-env", "lxd")
         other = type("SubSpec", (BootstrapSpec,), {})("my-env", "lxd")

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -22,6 +22,9 @@ class GetExecutableTests(unittest.TestCase):
         CFGDIR_ENVVAR = "JUJU_HOME"
 
     def test_full(self):
+        """
+        get_executable() works when all args are provided.
+        """
         exe = get_executable("spam", self.CLI, "/tmp", {"SPAM": "eggs"})
 
         self.assertEqual(
@@ -29,6 +32,9 @@ class GetExecutableTests(unittest.TestCase):
             _utils.Executable("spam", {"SPAM": "eggs", "JUJU_HOME": "/tmp"}))
 
     def test_minimal(self):
+        """
+        get_executable() works when given minimal args.
+        """
         exe = get_executable("spam", self.CLI, "/tmp")
 
         self.assertEqual(exe.filename, "spam")
@@ -36,16 +42,25 @@ class GetExecutableTests(unittest.TestCase):
         self.assertNotEqual(exe.envvars, {"JUJU_HOME": "/tmp"})
 
     def test_missing_filename(self):
+        """
+        get_executable() fails if filename is None or empty.
+        """
         with self.assertRaises(ValueError):
             get_executable("", self.CLI, "/tmp")
         with self.assertRaises(ValueError):
             get_executable(None, self.CLI, "/tmp")
 
     def test_missing_version_cli(self):
+        """
+        get_executable() fails if version_cli is None.
+        """
         with self.assertRaises(ValueError):
             get_executable("spam", None, "/tmp")
 
     def test_missing_cfgdir(self):
+        """
+        get_executable() fails if cfgdir is None or empty.
+        """
         with self.assertRaises(ValueError):
             get_executable("spam", self.CLI, None)
         with self.assertRaises(ValueError):
@@ -55,6 +70,9 @@ class GetExecutableTests(unittest.TestCase):
 class TestBootstrapSpec(unittest.TestCase):
 
     def test_full(self):
+        """
+        BootstrapSpec() works when all args are provided.
+        """
         spec = BootstrapSpec("my-env", "lxd", "xenial", "pw")
 
         self.assertEqual(spec.name, "my-env")
@@ -63,6 +81,9 @@ class TestBootstrapSpec(unittest.TestCase):
         self.assertEqual(spec.admin_secret, "pw")
 
     def test_minimal(self):
+        """
+        BootstrapSpec() works with minimal args.
+        """
         spec = BootstrapSpec("my-env", "lxd")
 
         self.assertEqual(spec.name, "my-env")
@@ -71,6 +92,9 @@ class TestBootstrapSpec(unittest.TestCase):
         self.assertIsNone(spec.admin_secret)
 
     def test_repr_full(self):
+        """
+        The repr of BootstrapSpec is correct.
+        """
         spec = BootstrapSpec("my-env", "lxd", "xenial", "pw")
         self.assertEqual(
             repr(spec),
@@ -79,6 +103,9 @@ class TestBootstrapSpec(unittest.TestCase):
             )
 
     def test_repr_minimal(self):
+        """
+        The repr of BootstrapSpec is correct even if some fields are missing.
+        """
         spec = BootstrapSpec("my-env", "lxd")
         self.assertEqual(
             repr(spec),
@@ -87,48 +114,77 @@ class TestBootstrapSpec(unittest.TestCase):
             )
 
     def test___eq___same_with_base_class(self):
+        """
+        BootstrapSpec == other is True when they are the same
+        and have the same class.
+        """
         spec = BootstrapSpec("my-env", "lxd")
         other = BootstrapSpec("my-env", "lxd")
 
         self.assertTrue(spec == other)
 
     def test___eq___same_with_sub_class(self):
+        """
+        BootstrapSpec == other is True when they are the same,
+        even if the other is a BootstrapSpec subclass.
+        """
         spec = BootstrapSpec("my-env", "lxd")
         other = type("SubSpec", (BootstrapSpec,), {})("my-env", "lxd")
 
         self.assertTrue(spec == other)
 
     def test___eq___same_with_other_class(self):
+        """
+        BootstrapSpec == other is True when they are the same,
+        even if the classes are different.
+        """
         spec = BootstrapSpec("my-env", "lxd", "trusty", "pw")
-        other_cls = namedtuple("Sub", "name driver default_series admin_secret")
+        other_cls = namedtuple("Sub",
+                               "name driver default_series admin_secret")
         other = other_cls("my-env", "lxd", "trusty", "pw")
 
         self.assertTrue(spec == other)
 
     def test___eq___identity(self):
+        """
+        For BootstrapSpec, spec == spec is True.
+        """
         spec = BootstrapSpec("my-env", "lxd")
 
         self.assertTrue(spec == spec)
 
     def test___eq___different(self):
+        """
+        BootstrapSpec == other is False when they differ.
+        """
         spec = BootstrapSpec("my-env", "lxd")
         other = BootstrapSpec("my-env", "spam")
 
         self.assertFalse(spec == other)
 
     def test___ne___same(self):
+        """
+        BootstrapSpec != other is False when they are the same.
+        """
         spec = BootstrapSpec("my-env", "lxd")
         other = BootstrapSpec("my-env", "lxd")
 
         self.assertFalse(spec != other)
 
     def test___ne___different(self):
+        """
+        BootstrapSpec != other is True when they differ.
+        """
         spec = BootstrapSpec("my-env", "lxd")
         other = BootstrapSpec("my-env", "spam")
 
         self.assertTrue(spec != other)
 
     def test_config(self):
+        """
+        BootstrapSpec.config() returns a Config containing
+        a ControllerConfig corresponding to the bootstrap spec.
+        """
         spec = BootstrapSpec("my-env", "lxd", "xenial", "pw")
         cfg = spec.config()
 
@@ -146,6 +202,9 @@ class TestBootstrapSpec(unittest.TestCase):
 class TestAPIInfo(unittest.TestCase):
 
     def test_full(self):
+        """
+        APIInfo() works with all args provided.
+        """
         endpoints = (u"host2", u"host1")
         info = APIInfo(endpoints, u"admin", u"pw", u"some-uuid")
 
@@ -155,6 +214,9 @@ class TestAPIInfo(unittest.TestCase):
         self.assertEqual(info.model_uuid, u"some-uuid")
 
     def test_minimal(self):
+        """
+        APIInfo() works with minimal args.
+        """
         endpoints = (u"host",)
         info = APIInfo(endpoints, u"admin", u"pw")
 
@@ -164,6 +226,9 @@ class TestAPIInfo(unittest.TestCase):
         self.assertIsNone(info.model_uuid)
 
     def test_conversion(self):
+        """
+        APIInfo() converts the args to unicode.
+        """
         endpoints = ["host2", "host1"]
         info = APIInfo(endpoints, "admin", "pw", "some-uuid")
 
@@ -173,24 +238,36 @@ class TestAPIInfo(unittest.TestCase):
         self.assertEqual(info.model_uuid, u"some-uuid")
 
     def test_missing_endpoints(self):
+        """
+        APIInfo() fails if endpoints is None or empty.
+        """
         with self.assertRaises(ValueError):
             APIInfo(None, "admin", "pw")
         with self.assertRaises(ValueError):
             APIInfo([], "admin", "pw")
 
     def test_missing_user(self):
+        """
+        APIInfo() fails if user is None or empty.
+        """
         with self.assertRaises(ValueError):
             APIInfo(["host"], None, "pw")
         with self.assertRaises(ValueError):
             APIInfo(["host"], "", "pw")
 
     def test_missing_password(self):
+        """
+        APIInfo() fails if password is None or empty.
+        """
         with self.assertRaises(ValueError):
             APIInfo(["host"], "admin", None)
         with self.assertRaises(ValueError):
             APIInfo(["host"], "admin", "")
 
     def test_address(self):
+        """
+        APIInfo.address holds the first endpoint.
+        """
         info = APIInfo(["host2", "host1"], "admin", "pw")
 
         self.assertEqual(info.address, "host2")

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -41,7 +41,7 @@ class TestBootstrapSpec(unittest.TestCase):
             cfg.controllers[0],
             config.ControllerConfig(
                 "my-env",
-                config.CloudConfig("my-env-lxd", "lxd"),
+                config.CloudConfig("lxd", "lxd"),
                 config.BootstrapConfig("xenial", "pw"),
                 ),
             )

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -58,7 +58,7 @@ class TestBootstrapSpec(unittest.TestCase):
         spec = BootstrapSpec("my-env", "lxd", "xenial", "pw")
 
         self.assertEqual(spec.name, "my-env")
-        self.assertEqual(spec.type, "lxd")
+        self.assertEqual(spec.driver, "lxd")
         self.assertEqual(spec.default_series, "xenial")
         self.assertEqual(spec.admin_secret, "pw")
 
@@ -66,7 +66,7 @@ class TestBootstrapSpec(unittest.TestCase):
         spec = BootstrapSpec("my-env", "lxd")
 
         self.assertEqual(spec.name, "my-env")
-        self.assertEqual(spec.type, "lxd")
+        self.assertEqual(spec.driver, "lxd")
         self.assertEqual(spec.default_series, "trusty")
         self.assertIsNone(spec.admin_secret)
 
@@ -74,7 +74,7 @@ class TestBootstrapSpec(unittest.TestCase):
         spec = BootstrapSpec("my-env", "lxd", "xenial", "pw")
         self.assertEqual(
             repr(spec),
-            ("BootstrapSpec(name='my-env', type='lxd', "
+            ("BootstrapSpec(name='my-env', driver='lxd', "
              "default_series='xenial', admin_secret='pw')"),
             )
 
@@ -82,7 +82,7 @@ class TestBootstrapSpec(unittest.TestCase):
         spec = BootstrapSpec("my-env", "lxd")
         self.assertEqual(
             repr(spec),
-            ("BootstrapSpec(name='my-env', type='lxd', "
+            ("BootstrapSpec(name='my-env', driver='lxd', "
              "default_series='trusty', admin_secret=None)"),
             )
 
@@ -100,7 +100,7 @@ class TestBootstrapSpec(unittest.TestCase):
 
     def test___eq___same_with_other_class(self):
         spec = BootstrapSpec("my-env", "lxd", "trusty", "pw")
-        other_cls = namedtuple("Sub", "name type default_series admin_secret")
+        other_cls = namedtuple("Sub", "name driver default_series admin_secret")
         other = other_cls("my-env", "lxd", "trusty", "pw")
 
         self.assertTrue(spec == other)

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -1,5 +1,6 @@
 # Copyright 2016 Canonical Limited.  All rights reserved.
 
+from collections import namedtuple
 import json
 import os
 import unittest
@@ -69,19 +70,64 @@ class TestBootstrapSpec(unittest.TestCase):
         self.assertEqual(spec.default_series, "trusty")
         self.assertIsNone(spec.admin_secret)
 
-    def test_repr(self):
+    def test_repr_full(self):
         spec = BootstrapSpec("my-env", "lxd", "xenial", "pw")
         self.assertEqual(
             repr(spec),
             ("BootstrapSpec(name='my-env', type='lxd', "
              "default_series='xenial', admin_secret='pw')"),
             )
+
+    def test_repr_minimal(self):
         spec = BootstrapSpec("my-env", "lxd")
         self.assertEqual(
             repr(spec),
             ("BootstrapSpec(name='my-env', type='lxd', "
              "default_series='trusty', admin_secret=None)"),
             )
+
+    def test___eq___same_with_base_class(self):
+        spec = BootstrapSpec("my-env", "lxd")
+        other = BootstrapSpec("my-env", "lxd")
+
+        self.assertTrue(spec == other)
+
+
+    def test___eq___same_with_sub_class(self):
+        spec = BootstrapSpec("my-env", "lxd")
+        other = type("SubSpec", (BootstrapSpec,), {})("my-env", "lxd")
+
+        self.assertTrue(spec == other)
+
+    def test___eq___same_with_other_class(self):
+        spec = BootstrapSpec("my-env", "lxd", "trusty", "pw")
+        other_cls = namedtuple("Sub", "name type default_series admin_secret")
+        other = other_cls("my-env", "lxd", "trusty", "pw")
+
+        self.assertTrue(spec == other)
+
+    def test___eq___identity(self):
+        spec = BootstrapSpec("my-env", "lxd")
+
+        self.assertTrue(spec == spec)
+
+    def test___eq___different(self):
+        spec = BootstrapSpec("my-env", "lxd")
+        other = BootstrapSpec("my-env", "spam")
+
+        self.assertFalse(spec == other)
+
+    def test___ne___same(self):
+        spec = BootstrapSpec("my-env", "lxd")
+        other = BootstrapSpec("my-env", "lxd")
+
+        self.assertFalse(spec != other)
+
+    def test___ne___different(self):
+        spec = BootstrapSpec("my-env", "lxd")
+        other = BootstrapSpec("my-env", "spam")
+
+        self.assertTrue(spec != other)
 
     def test_config(self):
         spec = BootstrapSpec("my-env", "lxd", "xenial", "pw")

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -16,7 +16,7 @@ from txjuju.errors import CLIError
 from txjuju.testing import TwistedTestCase
 
 
-class GetExecutableTests(unittest.TestCase):
+class GetExecutableTest(unittest.TestCase):
 
     class CLI(object):
         CFGDIR_ENVVAR = "JUJU_HOME"
@@ -67,7 +67,7 @@ class GetExecutableTests(unittest.TestCase):
             get_executable("spam", self.CLI, "")
 
 
-class TestBootstrapSpec(unittest.TestCase):
+class BootstrapSpecTest(unittest.TestCase):
 
     def test_full(self):
         """
@@ -199,7 +199,7 @@ class TestBootstrapSpec(unittest.TestCase):
             )
 
 
-class TestAPIInfo(unittest.TestCase):
+class APIInfoTest(unittest.TestCase):
 
     def test_full(self):
         """

--- a/txjuju/tests/test_config.py
+++ b/txjuju/tests/test_config.py
@@ -350,8 +350,8 @@ class ControllerConfigTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             ControllerConfig.from_info("", "lxd")
 
-    def test_from_info_missing_type(self):
-        """ControllerConfig.from_info() fails if type is None or empty."""
+    def test_from_info_missing_driver(self):
+        """ControllerConfig.from_info() fails if driver is None or empty."""
         with self.assertRaises(ValueError):
             ControllerConfig.from_info("spam", None)
         with self.assertRaises(ValueError):
@@ -431,7 +431,7 @@ class CloudConfigTest(unittest.TestCase):
         cfg = CloudConfig(u"spam", u"lxd", u"localhost:8080", None, None)
 
         self.assertEqual(cfg.name, u"spam")
-        self.assertEqual(cfg.type, u"lxd")
+        self.assertEqual(cfg.driver, u"lxd")
         self.assertEqual(cfg.endpoint, u"localhost:8080")
         self.assertIsNone(cfg.auth_types)
         self.assertIsNone(cfg.credentials)
@@ -441,7 +441,7 @@ class CloudConfigTest(unittest.TestCase):
         cfg = CloudConfig(u"lxd")
 
         self.assertEqual(cfg.name, u"lxd")
-        self.assertEqual(cfg.type, u"lxd")
+        self.assertEqual(cfg.driver, u"lxd")
         self.assertIsNone(cfg.endpoint)
         self.assertIsNone(cfg.auth_types)
         self.assertIsNone(cfg.credentials)
@@ -457,7 +457,7 @@ class CloudConfigTest(unittest.TestCase):
         cfg = CloudConfig("spam", "lxd", "localhost:8080")
 
         self.assertEqual(cfg.name, u"spam")
-        self.assertEqual(cfg.type, u"lxd")
+        self.assertEqual(cfg.driver, u"lxd")
         self.assertEqual(cfg.endpoint, u"localhost:8080")
         self.assertIsNone(cfg.auth_types)
         self.assertIsNone(cfg.credentials)
@@ -469,8 +469,8 @@ class CloudConfigTest(unittest.TestCase):
         with self.assertRaises(ValueError):
             CloudConfig("", "lxd")
 
-    def test_missing_type(self):
-        """CloudConfig() fails when type is empty."""
+    def test_missing_driver(self):
+        """CloudConfig() fails when driver is empty."""
         with self.assertRaises(ValueError):
             CloudConfig("spam", "")
 


### PR DESCRIPTION
An upcoming PR will add txjuju.cli.CLI, a generic wrapper around the Juju CLI.  This change adds some prerequisites:

* txjuju.cli.BootstrapSpec will be input to the upcoming CLI.bootstrap() method.
* txjuju.cli.APIInfo will be output from CLI.api_info().
* txjuju._utils.Executable encapsulates information about and interaction with
  a local executable file.
* txjuju.cli.get_executable() returns an Executable for a specific Juju version.
* txjuju.prepare_for_bootstrap() is a convenience helper for setting things up
  prior to bootstrapping with a given BootstrapSpec.

This PR is based on #4.