### PR TITLE
Add txjuju.cli.CLI, a generic Juju CLI abstraction.

### DIFF
--- a/txjuju/_juju2.py
+++ b/txjuju/_juju2.py
@@ -128,7 +128,7 @@ class CLIHooks(object):
             args += ["--no-gui"]
         if cfgfile:
             args += ["--config", cfgfile]
-        args += [spec.name, spec.driver]
+        args += [spec.driver, spec.name]
         return args
 
     def get_api_info_args(self, controller_name=None):

--- a/txjuju/_juju2.py
+++ b/txjuju/_juju2.py
@@ -4,6 +4,8 @@ import os.path
 
 import yaml
 
+from . import _utils
+
 
 class ConfigWriter(object):
     """The JujuConfig writer specific to Juju 2.x."""
@@ -107,3 +109,62 @@ class ConfigWriter(object):
                 # but currently fails on juju2beta6.
                 pass
             bootstraps[controller.name] = config
+
+
+class CLIHooks(object):
+
+    CFGDIR_ENVVAR = "JUJU_DATA"
+
+    def get_bootstrap_args(self, spec, to=None, cfgfile=None,
+                           verbose=False, gui=False, autoupgrade=False):
+        args = ["bootstrap"]
+        if verbose:
+            args += ["-v"]
+        if to:
+            args += ["--to", to]
+        if not autoupgrade:
+            args += ["--no-auto-upgrade"]
+        if not gui:
+            args += ["--no-gui"]
+        if cfgfile:
+            args += ["--config", cfgfile]
+        args += [spec.name, spec.driver]
+        return args
+
+    def get_api_info_args(self, controller_name=None):
+        args = ["show-controller", "--show-password", "--format=yaml"]
+        if controller_name is not None:
+            args += [controller_name]
+        return args
+
+    def parse_api_info(self, output, controller_name=None):
+        data = yaml.load(output, _utils.UnicodeYamlLoader)
+        if controller_name is None:
+            if len(data) > 1:
+                raise RuntimeError(
+                    "got back {} results, expected 1".format(len(data)))
+            _, data = data.popitem()
+        else:
+            data = data[controller_name]
+
+        info = {
+            "endpoints": data["details"]["api-endpoints"],
+            "user": data["account"]["user"].rstrip("@local"),
+            "password": data["account"]["password"],
+            "model_uuid": None,  # This will be set below for each model.
+            }
+        infos = {None: info}  # Start with the non-model API info.
+        for modelname, modelinfo in data["models"].items():
+            # Strip off the "<user>@local/" part.
+            modelname = modelname.rpartition("/")[2]
+            infos[modelname] = dict(info, model_uuid=modelinfo["uuid"])
+        return infos
+
+    def get_destroy_controller_args(self, name=None, force=False):
+        if force:
+            args = ["kill-controller", "--yes"]
+        else:
+            args = ["destroy-controller", "--yes", "--destroy-all-models"]
+        if name is not None:
+            args += [name]
+        return args

--- a/txjuju/_utils.py
+++ b/txjuju/_utils.py
@@ -3,6 +3,8 @@
 import subprocess
 from collections import namedtuple
 
+import yaml
+
 
 class Executable(namedtuple("Executable", "filename envvars")):
     """A single executable."""
@@ -51,3 +53,9 @@ class Executable(namedtuple("Executable", "filename envvars")):
         """
         args = self.resolve_args(*args)
         return subprocess.check_output(args, env=self.envvars, **kwargs)
+
+
+class UnicodeYamlLoader(yaml.Loader):
+    """yaml loader class returning unicode objects instead of python str."""
+UnicodeYamlLoader.add_constructor(
+    u'tag:yaml.org,2002:str', UnicodeYamlLoader.construct_scalar)

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -131,9 +131,19 @@ class APIInfo(namedtuple("APIInfo", "endpoints user password model_uuid")):
 
 
 class CLI(object):
+    """The client CLI for some Juju version."""
 
     @classmethod
     def from_version(cls, filename, version, cfgdir, envvars=None):
+        """Return a new CLI for the given binary and version.
+
+        @param filename: The path to the juju binary.
+        @param version: The Juju version to use.
+        @param cfgdir: The path to the "juju home" directory.
+        @param envvars: The extra environment variables to use when
+            running the juju command.  If not set then os.environs
+            is used.
+        """
         if not version:
             raise ValueError("missing version")
         elif version.startswith("1."):
@@ -147,6 +157,10 @@ class CLI(object):
         return cls(executable, juju)
 
     def __init__(self, executable, version_cli):
+        """
+        @param executable: The Executable to use.
+        @param version_cli: The version-specific subcommand handler.
+        """
         if not executable:
             raise ValueError("missing executable")
         if version_cli is None:
@@ -156,11 +170,25 @@ class CLI(object):
 
     def bootstrap(self, spec, to=None, cfgfile=None,
                   verbose=False, gui=False, autoupgrade=False):
+        """Bootstrap a new Juju controller.
+
+        @param spec: The BootstrapSpec to use.
+        @param to: The machine ID to which to deploy the API server.
+        @param cfgfile: The bootstrap config file to use.
+        @param verbose: Produce more verbose output.
+        @param gui: Install and start the JUJU GUI for the controller.
+        @param autoupgrade: Perform automatic upgrades of Ubuntu.
+        """
         args = self._juju.get_bootstrap_args(
             spec, to, cfgfile, verbose, gui, autoupgrade)
         self._exe.run(*args)
 
     def api_info(self, controller_name=None):
+        """Return {<model name>: APIInfo} for each of the controller's models.
+
+        One entry is included for the controller-level API facades.  The
+        key for that entry is None.
+        """
         args = self._juju.get_api_info_args(controller_name)
         out = self._exe.run_out(*args)
         infos = self._juju.parse_api_info(out, controller_name)
@@ -168,6 +196,7 @@ class CLI(object):
                 for modelname, info in infos.items()}
 
     def destroy_controller(self, name=None, force=False):
+        """Destroy the controller."""
         args = self._juju.get_destroy_controller_args(name, force)
         self._exe.run(*args)
 

--- a/txjuju/testing/__init__.py
+++ b/txjuju/testing/__init__.py
@@ -1,5 +1,7 @@
 # Copyright 2016 Canonical Limited.  All rights reserved.
 
+import os
+import os.path
 import signal
 
 from twisted.python import log
@@ -7,6 +9,52 @@ from twisted.python.failure import Failure
 from twisted.test.proto_helpers import MemoryReactorClock
 from twisted.trial.unittest import TestCase
 from twisted.web.test.test_newclient import StringTransport
+
+
+SCRIPT = """\
+#!/bin/bash
+
+echo $@ > {callfile}
+cat << EOF
+{output}
+EOF
+"""
+
+
+def write_script(dirname, filename="juju", output=None):
+    """Write the script to disk at the given location.
+
+    The script will be set with 755 permissions.
+    """
+    filename = os.path.join(dirname, filename)
+    callfile = os.path.join(dirname, ".called")
+    script = SCRIPT.format(callfile=callfile, output=output or "")
+    with open(filename, "w") as file:
+        file.write(script)
+    os.chmod(filename, 0o755)
+    return filename, callfile
+
+
+class StubExecutable(object):
+
+    def __init__(self, calls=None):
+        if calls is None:
+            calls = []
+        self.calls = calls
+
+        self.return_resolve_args = None
+        self.return_run_out = None
+
+    def resolve_args(self, *args):
+        self.calls.append(("resolve_args", args, {}))
+        return self.return_resolve_args
+
+    def run(self, *args, **kwargs):
+        self.calls.append(("run", args, kwargs))
+
+    def run_out(self, *args, **kwargs):
+        self.calls.append(("run_out", args, kwargs))
+        return self.return_run_out
 
 
 class TwistedTestCase(TestCase):

--- a/txjuju/testing/api.py
+++ b/txjuju/testing/api.py
@@ -2,9 +2,9 @@
 
 import json
 
-from twisted.python.failure import Failure
 from twisted.internet.error import ConnectionDone, ConnectionLost
 from twisted.internet.defer import Deferred
+from twisted.python.failure import Failure
 
 from txjuju.protocol import APIClientProtocol
 

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -431,7 +431,7 @@ class CLIJuju1Tests(unittest.TestCase):
 
     API_INFO_JSON = """\
 {
-    "state-servers": ["[fd1e:9828:924e:a48:216:3eff:fe7f:8125]:17070", "10.235.227.251:17070"],
+    "state-servers": ["10.235.227.251:17070"],
     "user": "admin",
     "password": "0f154812dd1c02973623c887b2565ea3",
     "environ-uuid": "d3a5befc-c392-4722-85fc-631531e74a09"
@@ -471,8 +471,21 @@ class CLIJuju1Tests(unittest.TestCase):
         filename, callfile = write_script(
             self.dirname, output=self.API_INFO_JSON)
         self.cli = CLI.from_version(filename, self.VERSION, self.dirname)
-        info = self.cli.api_info("spam")
+        infos = self.cli.api_info("spam")
 
+        self.assertEquals(infos, {
+            None: APIInfo(
+                ["10.235.227.251:17070"],
+                "admin",
+                "0f154812dd1c02973623c887b2565ea3",
+                ),
+            "controller": APIInfo(
+                ["10.235.227.251:17070"],
+                "admin",
+                "0f154812dd1c02973623c887b2565ea3",
+                "d3a5befc-c392-4722-85fc-631531e74a09",
+                ),
+            })
         self.assert_called(
             "api-info --password --refresh --format=json -e spam", callfile)
 
@@ -480,8 +493,21 @@ class CLIJuju1Tests(unittest.TestCase):
         filename, callfile = write_script(
             self.dirname, output=self.API_INFO_JSON)
         self.cli = CLI.from_version(filename, self.VERSION, self.dirname)
-        info = self.cli.api_info()
+        infos = self.cli.api_info()
 
+        self.assertEquals(infos, {
+            None: APIInfo(
+                ["10.235.227.251:17070"],
+                "admin",
+                "0f154812dd1c02973623c887b2565ea3",
+                ),
+            "controller": APIInfo(
+                ["10.235.227.251:17070"],
+                "admin",
+                "0f154812dd1c02973623c887b2565ea3",
+                "d3a5befc-c392-4722-85fc-631531e74a09",
+                ),
+            })
         self.assert_called(
             "api-info --password --refresh --format=json", callfile)
 
@@ -504,7 +530,7 @@ class CLIJuju2Tests(unittest.TestCase):
 spam:
   details:
     uuid: d3a5befc-c392-4722-85fc-631531e74a09
-    api-endpoints: ['[fd1e:9828:924e:a48:216:3eff:fe7f:8125]:17070', '10.235.227.251:17070']
+    api-endpoints: ['10.235.227.251:17070']
     ca-cert: |
       -----BEGIN CERTIFICATE-----
       MIIDzTCCArWgAwIBAgIUFnfJGYpNsh6YEHcLV6Nz1tvlAfUwDQYJKoZIhvcNAQEL
@@ -576,8 +602,27 @@ spam:
         filename, callfile = write_script(
             self.dirname, output=self.API_INFO_YAML)
         self.cli = CLI.from_version(filename, self.VERSION, self.dirname)
-        info = self.cli.api_info("spam")
+        infos = self.cli.api_info("spam")
 
+        self.assertEquals(infos, {
+            None: APIInfo(
+                ["10.235.227.251:17070"],
+                "admin",
+                "0f154812dd1c02973623c887b2565ea3",
+                ),
+            "controller": APIInfo(
+                ["10.235.227.251:17070"],
+                "admin",
+                "0f154812dd1c02973623c887b2565ea3",
+                "d3a5befc-c392-4722-85fc-631531e74a09",
+                ),
+            "default": APIInfo(
+                ["10.235.227.251:17070"],
+                "admin",
+                "0f154812dd1c02973623c887b2565ea3",
+                "b93f17f2-ad56-456d-8051-06e9f7ba46ec",
+                ),
+            })
         self.assert_called(
             "show-controller --show-password --format=yaml spam", callfile)
 
@@ -585,8 +630,27 @@ spam:
         filename, callfile = write_script(
             self.dirname, output=self.API_INFO_YAML)
         self.cli = CLI.from_version(filename, self.VERSION, self.dirname)
-        info = self.cli.api_info()
+        infos = self.cli.api_info()
 
+        self.assertEquals(infos, {
+            None: APIInfo(
+                ["10.235.227.251:17070"],
+                "admin",
+                "0f154812dd1c02973623c887b2565ea3",
+                ),
+            "controller": APIInfo(
+                ["10.235.227.251:17070"],
+                "admin",
+                "0f154812dd1c02973623c887b2565ea3",
+                "d3a5befc-c392-4722-85fc-631531e74a09",
+                ),
+            "default": APIInfo(
+                ["10.235.227.251:17070"],
+                "admin",
+                "0f154812dd1c02973623c887b2565ea3",
+                "b93f17f2-ad56-456d-8051-06e9f7ba46ec",
+                ),
+            })
         self.assert_called(
             "show-controller --show-password --format=yaml", callfile)
 

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -590,13 +590,13 @@ spam:
         self.cli.bootstrap(spec, "0", "bootstrap.yaml", True, True, True)
 
         self.assert_called(
-            "bootstrap -v --to 0 --config bootstrap.yaml spam lxd")
+            "bootstrap -v --to 0 --config bootstrap.yaml lxd spam")
 
     def test_bootstrap_minimal(self):
         spec = BootstrapSpec("spam", "lxd")
         self.cli.bootstrap(spec)
 
-        self.assert_called("bootstrap --no-auto-upgrade --no-gui spam lxd")
+        self.assert_called("bootstrap --no-auto-upgrade --no-gui lxd spam")
 
     def test_api_info_full(self):
         filename, callfile = write_script(


### PR DESCRIPTION
txjuju.cli.CLI will ultimately replace the existing version-specific CLI wrappers in txjuju.cli.  It will also be used to wrap fake-juju.  Currently only the subset of functionality needed from fake-juju is provided as CLI instance methods:

* bootstrap()
* api_info()
* destroy_controller()

A convenience factory method, CLI.from_version() is also provided.

This PR is based on #6.