### PR TITLE
Add python3 as a build dependency

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,6 +4,7 @@ Section: python
 Priority: optional
 Build-Depends: debhelper (>= 9),
                dh-python,
+               python3,
                python-all (>= 2.6.6-3),
                python-fixtures,
                python-setuptools (>= 0.6b3),


### PR DESCRIPTION
Add python3 as a build dependency to workaround missing dependency in dh-python (fixes #10).