### PR TITLE
Issue #1633071: Swap the bootstrap args for Juju 2.0rc3.

### DIFF
--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -156,7 +156,7 @@ class Juju2CLI(object):
         return self._run(
             ["bootstrap", "-v", "--no-gui", "--to", bootstrap_machine,
              "--auto-upgrade=false", "--config", bootstrap_config,
-             juju_controller_name, cloud_name])
+             cloud_name, juju_controller_name])
 
     def api_info(self, juju_controller_name):
         """Run get api info for the specified model/controller.

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -270,14 +270,14 @@ class Juju2CLITest(TwistedTestCase, MockerTestCase):
 
         out, _ = yield self.cli.bootstrap(
             self.model_name, self.bootstrap_machine, self.bootstrap_cloud)
-        self.assertEqual(
-            "bootstrap -v --no-gui --to {machine} --auto-upgrade=false "
-            "--config {home}/bootstrap.yaml {model_name} "
-            "landscape-maas".format(
-                model_name=self.model_name,
-                machine=self.bootstrap_machine,
-                home=self.juju_data),
-            out)
+
+        expected = ("bootstrap -v --no-gui --to {machine} "
+                    "--auto-upgrade=false --config {home}/bootstrap.yaml "
+                    "landscape-maas {model_name}"
+                    ).format(model_name=self.model_name,
+                             machine=self.bootstrap_machine,
+                             home=self.juju_data)
+        self.assertEqual(expected, out)
 
     @inlineCallbacks
     def test_auto_upgrades_disabled(self):


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/txjuju/+bug/1633071)

In juju-2.0rc3 the 2 arguments to "juju bootstrap" have been swapped so txjuju must adjust.