### PR TITLE
Fix FakeAPIBackend formatters for Juju 2.x.

### DIFF
--- a/txjuju/api.py
+++ b/txjuju/api.py
@@ -607,7 +607,10 @@ class Juju2APIClient(object):
         return response[self._getParam("watcher-id")]
 
     def _parseAllWatcherNext(self, response):
-        """Parse the response of an L{AllWatcherNext} request."""
+        """Parse the response of an AllWatcherNext request.
+
+        See github.com/juju/juju/state/multiwatcher/multiwatcher.go.
+        """
         deltas = []
         for kind, verb, data in response[self._getParam("deltas")]:
             info = self._parseAllWatcherNextDelta(kind, data)

--- a/txjuju/api.py
+++ b/txjuju/api.py
@@ -627,6 +627,7 @@ class Juju2APIClient(object):
         of deltas in a response to an AllWatcherNext Juju API request.
         """
         if kind == "unit":
+            # TODO: None of these should be optional (no data.get).
             status, statusInfo = self._getDeltaJujuStatus(data)
             info = UnitInfo(
                 data[self._getParam("name")],
@@ -641,6 +642,7 @@ class Juju2APIClient(object):
                 statusInfo=statusInfo,
                 )
         elif kind == "application":
+            # TODO: None of these should be optional (no data.get).
             info = ApplicationInfo(
                 data[self._getParam("name")],
                 exposed=data.get(self._getParam("exposed")),
@@ -655,6 +657,7 @@ class Juju2APIClient(object):
                 data[self._getParam("annotations")],
                 )
         elif kind == "machine":
+            # TODO: None of these should be optional (no data.get).
             status, statusInfo = self._getDeltaJujuStatus(data)
             # beta11 addresses will be None instead of [] when pending
             address = self._parseAddresses(

--- a/txjuju/testing/api.py
+++ b/txjuju/testing/api.py
@@ -201,6 +201,7 @@ class FakeAPIBackend(object):
                 "name": info.name,
                 "exposed": info.exposed,
                 }
+            # TODO: None of these should be optional except config.
             if info.charmURL is not None:
                 formatted["charm-url"] = info.charmURL
             if info.life is not None:
@@ -221,6 +222,7 @@ class FakeAPIBackend(object):
                 "name": info.name,
                 "application": info.applicationName,
                 }
+            # TODO: None of these should be optional.
             if info.series is not None:
                 formatted["series"] = info.series
             if info.charmURL is not None:
@@ -251,6 +253,7 @@ class FakeAPIBackend(object):
                 "id": info.id,
                 "instance-id": info.instanceId,
                 }
+            # TODO: None of these should be optional.
             if info.jobs is not None:
                 formatted["jobs"] = info.jobs
             if info.address is not None:


### PR DESCRIPTION
During formatting, some info fields were skipped and the status fields were wrong.