### PR TITLE
Use 'PyYAML' instead of 'yaml'.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ for path, dirs, files in os.walk(package_name):
 
 DEPS = [
         'twisted',
-        'pyyaml',
+        'PyYAML',
         ]
 TESTING_DEPS = [
         'fixtures',

--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ for path, dirs, files in os.walk(package_name):
 
 DEPS = [
         'twisted',
-        'yaml',
+        'pyyaml',
         ]
 TESTING_DEPS = [
         'fixtures',


### PR DESCRIPTION
Fixes #27.

Tested by building precise, trusty, xenial, yakkety and zesty packages with sbuild.
Also tested that fake-juju's `make install` works with this in a yakkety lxc.