### PR TITLE
Use juju-2.1 as a fallback.

### DIFF
--- a/txjuju/__init__.py
+++ b/txjuju/__init__.py
@@ -17,8 +17,8 @@ __all__ = [
 __version__ = "0.9.0a1"
 
 
-JUJU1 = "juju"
-JUJU2 = "juju-2.0"
+JUJU1 = "juju-1"
+JUJU2 = "juju-2"
 
 
 def get_cli_class(release=JUJU1):

--- a/txjuju/_utils.py
+++ b/txjuju/_utils.py
@@ -1,5 +1,6 @@
 # Copyright 2016 Canonical Limited.  All rights reserved.
 
+import os.path
 import subprocess
 from collections import namedtuple
 
@@ -25,6 +26,8 @@ class Executable(namedtuple("Executable", "filename envvars")):
     def __init__(self, *args, **kwargs):
         if not self.filename:
             raise ValueError("missing filename")
+        if not os.path.isabs(self.filename):
+            raise ValueError("filename must be an absolute path")
 
     @property
     def envvars(self):

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -36,7 +36,8 @@ JUJU1 = _find_best_juju([
 JUJU2 = _find_best_juju([
         "juju-2",
         "juju-2.0",  # the latest production release
-        # (lp:1650644) For now we must accommodate varying binary paths.
+        # TODO: (lp:1650644, lp:1646223)
+        #  For now we must accommodate varying binary paths.
         # TODO: make sure txjuju works with Juju 2.1.
         "juju-2.1",  # the latest development release
         ])

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -35,7 +35,7 @@ def get_executable(filename, version_cli, cfgdir, envvars=None):
     envvars = dict(envvars)
     envvars[version_cli.CFGDIR_ENVVAR] = cfgdir
 
-    return _utils.Executable(filename, envvars)
+    return _utils.Executable.find(filename, envvars)
 
 
 class BootstrapSpec(object):

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -159,6 +159,8 @@ class APIInfo(namedtuple("APIInfo", "endpoints user password model_uuid")):
 class CLI(object):
     """The client CLI for some Juju version."""
 
+    # TODO: Add from_filename() that uses --version to determine the version.
+
     @classmethod
     def from_version(cls, filename, version, cfgdir, envvars=None):
         """Return a new CLI for the given binary and version.

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -30,10 +30,12 @@ def _find_best_juju(supported):
 
 
 JUJU1 = _find_best_juju([
+        # The first entry is also used as the default.
         "juju-1",
         "juju-1.25",
         ])
 JUJU2 = _find_best_juju([
+        # The first entry is also used as the default.
         "juju-2",
         "juju-2.0",  # the latest production release
         # TODO: (lp:1650644, lp:1646223)

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -35,8 +35,10 @@ JUJU1 = _find_best_juju([
         ])
 JUJU2 = _find_best_juju([
         "juju-2",
-        # (lp:1650644) For now we must accommodate varying binary paths.
         "juju-2.0",  # the latest production release
+        # (lp:1650644) For now we must accommodate varying binary paths.
+        # TODO: make sure txjuju works with Juju 2.1.
+        "juju-2.1",  # the latest development release
         ])
 
 

--- a/txjuju/cli.py
+++ b/txjuju/cli.py
@@ -17,6 +17,29 @@ from . import config, _utils, _juju1, _juju2
 from .errors import CLIError
 
 
+def _find_best_juju(supported):
+    for juju in supported:
+        try:
+            _utils.Executable.find(juju)
+        except _utils.ExecutableNotFoundError:
+            continue
+        else:
+            return juju
+    else:
+        return supported[0]
+
+
+JUJU1 = _find_best_juju([
+        "juju-1",
+        "juju-1.25",
+        ])
+JUJU2 = _find_best_juju([
+        "juju-2",
+        # (lp:1650644) For now we must accommodate varying binary paths.
+        "juju-2.0",  # the latest production release
+        ])
+
+
 def get_executable(filename, version_cli, cfgdir, envvars=None):
     """Return the Executable for the given juju binary.
 
@@ -213,7 +236,7 @@ class Juju1CLI(object):
 
     # Allow override for testing purposes, normal use should not need
     # to change this.
-    juju_binary_path = "juju"
+    juju_binary_path = JUJU1
 
     def __init__(self, juju_home):
         self.juju_home = juju_home
@@ -332,7 +355,7 @@ class Juju2CLI(object):
 
     # Allow override for testing purposes, normal use should not need
     # to change this.
-    juju_binary_path = "juju-2.0"
+    juju_binary_path = JUJU2
 
     def __init__(self, juju_data):
         """The JUJU_DATA path, previously referred as JUJU_HOME."""

--- a/txjuju/tests/test__utils.py
+++ b/txjuju/tests/test__utils.py
@@ -33,27 +33,28 @@ class ExecutableTests(unittest.TestCase):
         """
         Executable() works when provided all arguments.
         """
-        exe = Executable("my-exe", {"SPAM": "eggs"})
+        exe = Executable("/usr/local/bin/my-exe", {"SPAM": "eggs"})
 
-        self.assertEqual(exe.filename, "my-exe")
+        self.assertEqual(exe.filename, "/usr/local/bin/my-exe")
         self.assertEqual(exe.envvars, {"SPAM": "eggs"})
 
     def test_minimal(self):
         """
         Executable() works with minimal arguments.
         """
-        exe = Executable("my-exe")
+        exe = Executable("/usr/local/bin/my-exe")
 
-        self.assertEqual(exe.filename, "my-exe")
+        self.assertEqual(exe.filename, "/usr/local/bin/my-exe")
         self.assertIsNone(exe.envvars)
 
     def test_conversion(self):
         """
         Executable() converts the args to str.
         """
-        exe = Executable(u"my-exe", [(u"SPAM", u"eggs"), ("ham", "")])
+        exe = Executable(
+            u"/usr/local/bin/my-exe", [(u"SPAM", u"eggs"), ("ham", "")])
 
-        self.assertEqual(exe.filename, "my-exe")
+        self.assertEqual(exe.filename, "/usr/local/bin/my-exe")
         self.assertEqual(exe.envvars, {"SPAM": "eggs"})
 
     def test_missing_filename(self):
@@ -69,7 +70,7 @@ class ExecutableTests(unittest.TestCase):
         """
         Executable.envvars gives a copy of the originally provided env vars.
         """
-        exe = Executable("my-exe", {"SPAM": "eggs"})
+        exe = Executable("/usr/local/bin/my-exe", {"SPAM": "eggs"})
         exe.envvars["SPAM"] = "ham"
 
         self.assertEqual(exe.envvars, {"SPAM": "eggs"})
@@ -79,10 +80,10 @@ class ExecutableTests(unittest.TestCase):
         Executable.resolve_args() returns the args list that may
         be passed to subprocess.*().
         """
-        exe = Executable("my-exe", {"SPAM": "eggs"})
+        exe = Executable("/usr/local/bin/my-exe", {"SPAM": "eggs"})
         args = exe.resolve_args("x", "-y", "z")
 
-        self.assertEqual(args, ["my-exe", "x", "-y", "z"])
+        self.assertEqual(args, ["/usr/local/bin/my-exe", "x", "-y", "z"])
 
     def test_run(self):
         """

--- a/txjuju/tests/test__utils.py
+++ b/txjuju/tests/test__utils.py
@@ -38,7 +38,7 @@ class ExecutableTests(unittest.TestCase):
         """
         exe = Executable.find("python2")
 
-        self.assertEqual(exe.filename, "/usr/bin/python2")
+        self.assertTrue(exe.filename.endswith("/bin/python2"))
         self.assertIsNone(exe.envvars)
 
     def test_find_does_not_exist(self):

--- a/txjuju/tests/test__utils.py
+++ b/txjuju/tests/test__utils.py
@@ -105,7 +105,7 @@ class ExecutableTests(unittest.TestCase):
 
         self.assertEqual(args, ["/usr/local/bin/my-exe", "x", "-y", "z"])
 
-    def test_run(self):
+    def test_run_exists(self):
         """
         Executable.run() runs the command and returns nothing.
         """
@@ -119,7 +119,17 @@ class ExecutableTests(unittest.TestCase):
         self.assertTrue(out.startswith("x -y z\n"))
         self.assertIn("SPAM=eggs\n", out)
 
-    def test_run_out(self):
+    def test_run_executable_does_not_exist(self):
+        """
+        Executable.run() fails if the executable does not exist.
+        """
+        filename = self._resolve_executable("does-not-exist")
+        exe = Executable(filename)
+
+        with self.assertRaises(ExecutableNotFoundError):
+            exe.run()
+
+    def test_run_out_exists(self):
         """
         Executable.run_out() runs the command and returns stdout.
         """
@@ -130,3 +140,13 @@ class ExecutableTests(unittest.TestCase):
 
         self.assertTrue(out.startswith("x -y z\n"))
         self.assertIn("SPAM=eggs\n", out)
+
+    def test_run_executable_does_not_exist(self):
+        """
+        Executable.run_out() fails if the executable does not exist.
+        """
+        filename = self._resolve_executable("does-not-exist")
+        exe = Executable(filename)
+
+        with self.assertRaises(ExecutableNotFoundError):
+            exe.run_out()

--- a/txjuju/tests/test_cli.py
+++ b/txjuju/tests/test_cli.py
@@ -26,8 +26,11 @@ class GetExecutableTest(unittest.TestCase):
 
     def setUp(self):
         self.dirname = tempfile.mkdtemp(prefix="txjuju-test-")
+        self.os_env_orig = os.environ.copy()
 
     def tearDown(self):
+        os.environ.clear()
+        os.environ.update(self.os_env_orig)
         shutil.rmtree(self.dirname)
         super(GetExecutableTest, self).tearDown()
 
@@ -62,6 +65,17 @@ class GetExecutableTest(unittest.TestCase):
         self.assertEqual(exe.filename, filename)
         self.assertEqual(exe.envvars["JUJU_HOME"], "/tmp")
         self.assertNotEqual(exe.envvars, {"JUJU_HOME": "/tmp"})
+
+    def test_relative_filename(self):
+        """
+        get_executable() searches for the executable if the provided
+        filename is relative.
+        """
+        filename = self._write_executable("spam")
+        os.environ["PATH"] = self.dirname
+        exe = get_executable("spam", self.CLI, "/tmp")
+
+        self.assertEqual(exe.filename, filename)
 
     def test_missing_filename(self):
         """


### PR DESCRIPTION
(fixes https://bugs.launchpad.net/landscape/+bug/1650644)

Currently "juju-2.0" is hard-coded as the binary name.  This change adds more flexibility and makes an attempt at using a binary that actually exists.

Note that this patch does more than the minimum to fix the bug.  This is because we will likely run into this problem again and again, so a slightly broader solution is warranted.  At the same time, an even broader solution is arguably valid here by the same reasoning.  However, that can be addressed separately if it's worth bothering.

Also note that this branch does not actually make any effort toward compatibility with Juju 2.1 (if any is required).  Instead it opens the door for such efforts, allowing us to run the landscape system tests using 2.1.