### PR TITLE
Be quieter in logging

### DIFF
--- a/txjuju/__init__.py
+++ b/txjuju/__init__.py
@@ -14,7 +14,7 @@ __all__ = [
     ]
 
 
-__version__ = "0.9.0a1"
+__version__ = "0.9.0a2"
 
 
 JUJU1 = "juju-1"

--- a/txjuju/_twisted/tests/__init__.py
+++ b/txjuju/_twisted/tests/__init__.py
@@ -1,0 +1,1 @@
+# Copyright 2017 Canonical Limited.  All rights reserved.

--- a/txjuju/_twisted/tests/test_websocketsclient.py
+++ b/txjuju/_twisted/tests/test_websocketsclient.py
@@ -1,0 +1,38 @@
+# Copyright 2017 Canonical Limited.  All rights reserved.
+
+import unittest
+
+from twisted.logger import globalLogPublisher
+
+from ..websockets import STATUSES
+from ..websocketsclient import WebSocketsClientFactory, log_closed_connection
+
+
+class WebSocketsClientFactorTest(unittest.TestCase):
+
+    def test_is_not_noisy(self):
+        """WebSocketsClientFactory is not noisy"""
+        self.assertFalse(WebSocketsClientFactory.noisy)
+
+
+class LogClosedConnectionTest(unittest.TestCase):
+
+    def setUp(self):
+        """Capture logs."""
+        super(LogClosedConnectionTest, self).setUp()
+        self.log_events = []
+        globalLogPublisher.addObserver(self.log_events.append)
+
+    def test_no_log_for_normal(self):
+        """There is no log emitted for normal connection closing."""
+        log_closed_connection((STATUSES.NORMAL, None))
+        self.assertEqual([], self.log_events)
+
+    def test_log_for_abnormal(self):
+        """Abnormal closing is logged."""
+        log_closed_connection((STATUSES.ABNORMAL_CLOSE, "foo"))
+        self.assertEqual(1, len(self.log_events))
+        log_event = self.log_events[0]
+        self.assertEqual(
+            "Closing connection: {!r} ('foo')".format(STATUSES.ABNORMAL_CLOSE),
+            log_event["log_text"])

--- a/txjuju/_twisted/tests/test_websocketsclient.py
+++ b/txjuju/_twisted/tests/test_websocketsclient.py
@@ -22,6 +22,8 @@ class LogClosedConnectionTest(unittest.TestCase):
         super(LogClosedConnectionTest, self).setUp()
         self.log_events = []
         globalLogPublisher.addObserver(self.log_events.append)
+        self.addCleanup(
+            globalLogPublisher.removeObserver, self.log_events.append)
 
     def test_no_log_for_normal(self):
         """There is no log emitted for normal connection closing."""

--- a/txjuju/_twisted/websocketsclient.py
+++ b/txjuju/_twisted/websocketsclient.py
@@ -63,13 +63,7 @@ class _FrameParser(WebSocketsProtocol):
             self._receiver.frameReceived(opcode, data, fin)
             if opcode == CONTROLS.CLOSE:
                 # The other side wants us to close.
-                code, reason = data
-                msgFormat = "Closing connection: %(code)r"
-                if reason:
-                    msgFormat += " (%(reason)r)"
-                if code is not STATUSES.NORMAL:
-                    log.msg(format=msgFormat, reason=reason, code=code)
-
+                log_closed_connection(data)
                 # Close the connection.
                 self.transport.loseConnection()
                 return
@@ -78,6 +72,16 @@ class _FrameParser(WebSocketsProtocol):
                 # 5.5.3 PONGs must contain the data that was sent with the
                 # provoking PING.
                 self.transport.write(_makeFrame(data, CONTROLS.PONG, True))
+
+
+def log_closed_connection(data):
+    """Log the reason for closing the connection, if significant."""
+    code, reason = data
+    msgFormat = "Closing connection: %(code)r"
+    if reason:
+        msgFormat += " (%(reason)r)"
+    if code is not STATUSES.NORMAL:
+        log.msg(format=msgFormat, reason=reason, code=code)
 
 
 class _FrameSender(WebSocketsTransport):

--- a/txjuju/_twisted/websocketsclient.py
+++ b/txjuju/_twisted/websocketsclient.py
@@ -336,6 +336,7 @@ class WebSocketsClientFactory(Factory):
     """
     protocol = WebSocketsClientProtocol
     handshake = None
+    noisy = False
 
     def setHandshake(self, handshake):
         """Set the L{Handshake} to use when sending the handshake request."""


### PR DESCRIPTION
Set noisy to `False` to avoid the plentiful "Starting factory" and "Stopping factory" log messages (fixes #41 )

Additionally, remove the logging of normal closing of connections (whilst retaining it for non-normal cases).

To test this by hand, one can use this code in an existing codebase, and see log messages that have much higher signal to noise.