### PR TITLE
Re-enable integration tests, using the new fakejuju fixture

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,17 @@
-dist: trusty
 sudo: true
 language: python
 python:
  - "2.7"
+addons:
+  apt:
+    sources:
+      - mongodb-3.0-precise
+    packages:
+      - mongodb-org-server
+before_install:
+  - sudo add-apt-repository ppa:fake-juju/master -y
+  - sudo apt-get update -q
+  - sudo apt-get install -y fake-juju
 install:
  - pip install twisted fixtures PyYAML testtools pyOpenSSL mocker
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: trusty
+sudo: true
 language: python
 python:
  - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,11 @@ before_install:
   - sudo add-apt-repository ppa:fake-juju/master -y
   - sudo apt-get update -q
   - sudo apt-get install -y fake-juju
+env:
+  global:
+    - JUJU_MONGOD=/usr/bin/mongod
 install:
- - pip install twisted fixtures PyYAML testtools pyOpenSSL mocker
+ - pip install twisted==16.0.0 fixtures PyYAML testtools pyOpenSSL mocker fakejuju git+https://github.com/testing-cabal/testresources.git#egg=testresources
 script:
  - make test
+ - make integration-test

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ test:
 
 .PHONY: integration-test
 integration-test:
-	$(PYTHON) -m unittest discover -t $(shell pwd) -s $(shell pwd)/tests
+	$(PYTHON) -m testtools.run discover -t . -s tests
 
 .PHONY: coverage
 coverage:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,1 +1,11 @@
 # Copyright 2016 Canonical Limited.  All rights reserved.
+import os
+
+from testresources import OptimisingTestSuite
+
+
+def load_tests(loader, standard_tests, pattern):
+    this_dir = os.path.dirname(__file__)
+    package_tests = loader.discover(start_dir=this_dir, pattern=pattern)
+    standard_tests.addTests(package_tests)
+    return OptimisingTestSuite(standard_tests)

--- a/tests/resources.py
+++ b/tests/resources.py
@@ -1,0 +1,13 @@
+from testresources import FixtureResource
+
+from fixtures import FakeLogger
+
+from txfixtures import Reactor
+
+from fakejuju.fixture import FakeJuju
+
+# Resource tree
+logger = FixtureResource(FakeLogger())
+reactor = FixtureResource(Reactor())
+fakejuju = FixtureResource(FakeJuju(reactor.fixture))
+fakejuju.resources = [("logger", logger), ("reactor", reactor)]

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -29,7 +29,7 @@ class JujuAPIClientIntegrationTest(TestCase, ResourcedTestCase):
         cli.execute("bootstrap", "foo", "bar")
         self.addCleanup(cli.execute, "destroy-controller", "-y", "bar")
 
-        addr = "localhost:%d" % (self.fakejuju.port - 1)
+        addr = self.fakejuju.address
         self.endpoint = Endpoint(reactor, addr, JujuAPIClient, uuid=MODEL_UUID)
         self.client = yield self.endpoint.connect()
 

--- a/txjuju/api.py
+++ b/txjuju/api.py
@@ -111,7 +111,7 @@ class Endpoint(object):
         return uri
 
 
-class Juju2APIClient(object):
+class JujuAPIClient(object):
     """Client for the Juju 2.0 API.
 
     Each method of this class will perform the relevant Juju 2.0 API request
@@ -781,7 +781,7 @@ class Juju2APIClient(object):
             _handle_api_error(result)
 
 
-class Juju1APIClient(Juju2APIClient):
+class Juju1APIClient(JujuAPIClient):
     """Client for the Juju 1.X API.
 
     XXX bug #1558600 duplication to be removed with "juju-2.0" feature flag.
@@ -995,3 +995,7 @@ def _handle_api_error(result):
     except KeyError:
         raise APIRequestError("malformed result {}".format(result), "")
     raise APIRequestError(msg, code)
+
+
+# For backward-compatibility
+Juju2APIClient = JujuAPIClient


### PR DESCRIPTION
Integration tests had been disabled in Travis, presumably the txjuju was moved to GitHub and/or juju 2 support was added.

This branch re-enables them, leveraging the new Python fixtures introduced in fake-juju after the 2.0.2 rewrite.

The tests have already caught issue #45, which requires to pin the Twisted version used by the tests.

The testresources version is also pinned, pointing to the master branch in the upstream test-cabal repository, since the testing code in txjuju depends on an unreleased bug-fix.